### PR TITLE
ヘッダー右部分の編集

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -60,3 +60,5 @@ gem 'devise'
 
 gem 'carrierwave'
 gem 'mini_magick'
+
+gem 'pry-rails'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -52,6 +52,7 @@ GEM
       image_processing (~> 1.1)
       mimemagic (>= 0.3.0)
       mini_mime (>= 0.1.3)
+    coderay (1.1.2)
     coffee-rails (4.2.2)
       coffee-script (>= 2.2.0)
       railties (>= 4.0.0)
@@ -118,6 +119,11 @@ GEM
     nokogiri (1.10.4)
       mini_portile2 (~> 2.4.0)
     orm_adapter (0.5.0)
+    pry (0.12.2)
+      coderay (~> 1.1.0)
+      method_source (~> 0.9.0)
+    pry-rails (0.3.9)
+      pry (>= 0.10.4)
     public_suffix (4.0.1)
     puma (3.12.1)
     rack (2.0.7)
@@ -217,6 +223,7 @@ DEPENDENCIES
   listen (~> 3.0.5)
   mini_magick
   mysql2 (>= 0.3.18, < 0.6.0)
+  pry-rails
   puma (~> 3.0)
   rails (~> 5.0.7, >= 5.0.7.2)
   sass-rails (~> 5.0)

--- a/app/assets/stylesheets/_messages.scss
+++ b/app/assets/stylesheets/_messages.scss
@@ -103,6 +103,7 @@
         }
       }
       &__edit-btn {
+        cursor: pointer;
         position: absolute;
         right: 40px;
         height: 40px;

--- a/app/controllers/groups_controller.rb
+++ b/app/controllers/groups_controller.rb
@@ -4,6 +4,9 @@ class GroupsController < ApplicationController
   def index
   end
 
+  def edit
+  end
+
   def new
     @group = Group.new
     @group.users << current_user

--- a/app/controllers/groups_controller.rb
+++ b/app/controllers/groups_controller.rb
@@ -4,9 +4,6 @@ class GroupsController < ApplicationController
   def index
   end
 
-  def edit
-  end
-
   def new
     @group = Group.new
     @group.users << current_user

--- a/app/views/messages/index.html.haml
+++ b/app/views/messages/index.html.haml
@@ -10,7 +10,7 @@
         %ul.left-header__members
           Member：
           %li.member
-            = @group_users.user @group.name
+            = @group.name
       .right-header
         = link_to 'Edit', edit_group_path(current_user), class: 'right-header__button'
     .messages

--- a/app/views/messages/index.html.haml
+++ b/app/views/messages/index.html.haml
@@ -10,7 +10,7 @@
         %ul.left-header__members
           Member：
           %li.member
-            = @group.name
+            = @group.users.pluck(:name).join(", ")
       .right-header
         = link_to 'Edit', edit_group_path(current_user), class: 'right-header__button'
     .messages

--- a/app/views/messages/index.html.haml
+++ b/app/views/messages/index.html.haml
@@ -6,18 +6,13 @@
     .header
       .left-header
         .left-header__title
-          グループ名
+          = @group.name
         %ul.left-header__members
           Member：
           %li.member
-            メンバー名
-          %li.member
-            メンバー名
-          %li.member
-            メンバー名
+            = @group_users.user @group.name
       .right-header
-        .right-header__button
-          Edit
+        = link_to 'Edit', edit_group_path(current_user), class: 'right-header__button'
     .messages
       = render @messages
     .form


### PR DESCRIPTION
What
ヘッダーのグループ名に当該グループの名前、
及びグループに所属している ユーザーの名前も表示。

Why
テンプレートのグループ名とユーザー名が表示されているため